### PR TITLE
Add reference attribute to Wizard::Base

### DIFF
--- a/lib/dfe_wizard/base.rb
+++ b/lib/dfe_wizard/base.rb
@@ -52,6 +52,10 @@ module DFEWizard
 
     def matchback_attributes; end
 
+    def reference
+      self.class.to_s.gsub("Wizard", "").underscore
+    end
+
     def find(key)
       step(key).new self, @store
     end

--- a/lib/dfe_wizard/version.rb
+++ b/lib/dfe_wizard/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DFEWizard
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 end

--- a/spec/dfe_wizard/base_spec.rb
+++ b/spec/dfe_wizard/base_spec.rb
@@ -101,6 +101,12 @@ describe DFEWizard::Base do
     end
   end
 
+  describe "#reference" do
+    subject { wizard.reference }
+
+    it { is_expected.to eq("test") }
+  end
+
   describe "#process_magic_link_token" do
     let(:token) { "magic-link-token" }
     let(:stub_response) do

--- a/spec/dfe_wizard_spec.rb
+++ b/spec/dfe_wizard_spec.rb
@@ -6,6 +6,6 @@ RSpec.describe DFEWizard do
   describe "VERSION" do
     subject { described_class::VERSION }
 
-    it { is_expected.to eql "0.1.0" }
+    it { is_expected.to eql "0.1.1" }
   end
 end


### PR DESCRIPTION
When we make requests to the API it is able to determine the client/service making the request, however it would be beneficial to include a transaction-level reference for certain metrics.

Add `reference` attribute to `Wizard::Base` that populates with the name of the wizard/transaction. For example,
`MailingListWizard` will have the reference `mailing_list`.