### PR TITLE
Implement issue verification code functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ bin
 .idea
 *.log
 spec/dummy/db/
+.byebug_history

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -29,6 +29,10 @@ RSpec/LeadingSubject:
 RSpec/NestedGroups:
   Max: 6
 
+RSpec/ExpectInHook:
+  Exclude:
+    - spec/**/*.rb
+
 RSpec/MessageSpies:
   Exclude:
     - spec/**/*.rb

--- a/Gemfile
+++ b/Gemfile
@@ -10,5 +10,6 @@ gem "get_into_teaching_api_client_faraday", github: "DFE-Digital/get-into-teachi
 gem "tzinfo-data", platforms: %i[mingw mswin x64_mingw jruby]
 
 group :test do
+  gem "byebug"
   gem "shoulda-matchers", "~> 5.0"
 end

--- a/lib/dfe_wizard.rb
+++ b/lib/dfe_wizard.rb
@@ -8,6 +8,7 @@ require "dfe_wizard/store"
 require "dfe_wizard/step"
 require "dfe_wizard/base"
 require "dfe_wizard/controller"
+require "dfe_wizard/issue_verification_code"
 
 module DFEWizard
 end

--- a/lib/dfe_wizard/base.rb
+++ b/lib/dfe_wizard/base.rb
@@ -53,7 +53,7 @@ module DFEWizard
     def matchback_attributes; end
 
     def reference
-      self.class.to_s.gsub("Wizard", "").underscore
+      self.class.to_s.underscore.gsub("/", "_")
     end
 
     def find(key)
@@ -152,11 +152,13 @@ module DFEWizard
     end
 
     def process_access_token(token, request)
+      request.reference = reference
       response = exchange_access_token(token, request)
       prepopulate_store(response, Auth::ACCESS_TOKEN)
     end
 
     def process_unverified_request(request)
+      request.reference = "#{reference}-unverified"
       response = exchange_unverified_request(request)
       prepopulate_store(response, Auth::UNVERIFIED)
     end

--- a/lib/dfe_wizard/issue_verification_code.rb
+++ b/lib/dfe_wizard/issue_verification_code.rb
@@ -1,0 +1,50 @@
+module DFEWizard
+  module IssueVerificationCode
+    extend ActiveSupport::Concern
+
+    def save
+      if valid?
+        purge_store_retaining_matchback_failures
+
+        Rails.logger.info("#{self.class} requesting access code")
+
+        begin
+          request = GetIntoTeachingApiClient::ExistingCandidateRequest.new(request_attributes)
+          GetIntoTeachingApiClient::CandidatesApi.new.create_candidate_access_token(request)
+          @store["authenticate"] = true
+        rescue GetIntoTeachingApiClient::ApiError => e
+          @store["matchback_failures"] += 1
+          @store["last_matchback_failure_code"] = e.code
+
+          raise if e.code == 429
+
+          Rails.logger.info("#{self.class} potential duplicate (response code #{e.code})") unless e.code == 404
+
+          # Existing candidate not found or CRM is currently unavailable.
+          @store["authenticate"] = false
+        end
+      end
+
+      super
+    end
+
+  private
+
+    def purge_store_retaining_matchback_failures
+      matchback_failures = @store["matchback_failures"] || 0
+      last_matchback_failure_code = @store["last_matchback_failure_code"]
+
+      @store.purge!
+
+      @store["matchback_failures"] = matchback_failures
+      @store["last_matchback_failure_code"] = last_matchback_failure_code
+    end
+
+    def request_attributes
+      attributes
+        .slice("email", "first_name", "last_name")
+        .merge({ "reference" => @wizard.reference })
+        .transform_keys { |k| k.camelize(:lower).to_sym }
+    end
+  end
+end

--- a/lib/dfe_wizard/steps/authenticate.rb
+++ b/lib/dfe_wizard/steps/authenticate.rb
@@ -51,7 +51,8 @@ module DFEWizard
       end
 
       def timed_one_time_password_is_correct
-        request = GetIntoTeachingApiClient::ExistingCandidateRequest.new(candidate_identity_data)
+        params = candidate_identity_data.merge({ reference: @wizard.reference })
+        request = GetIntoTeachingApiClient::ExistingCandidateRequest.new(params)
         if timed_one_time_password_changed?
           clear_attribute_changes(%i[timed_one_time_password])
           @wizard.process_access_token(timed_one_time_password, request)

--- a/lib/dfe_wizard/version.rb
+++ b/lib/dfe_wizard/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DFEWizard
-  VERSION = "0.1.1"
+  VERSION = "1.0.0"
 end

--- a/spec/dfe_wizard/controller_spec.rb
+++ b/spec/dfe_wizard/controller_spec.rb
@@ -94,6 +94,7 @@ describe "EventStepsController", type: :request do
         firstName: "John",
         lastName: "Doe",
         email: "john@doe.com",
+        reference: "events_wizard-unverified",
       }
     end
 

--- a/spec/dfe_wizard/issue_verification_code_spec.rb
+++ b/spec/dfe_wizard/issue_verification_code_spec.rb
@@ -1,0 +1,141 @@
+require "rails_helper"
+
+describe DFEWizard::IssueVerificationCode do
+  subject { IssueVerificationCodeStep.new wizard, wizardstore, attributes }
+
+  include_context "with wizard store"
+
+  class IssueVerificationCodeStep < DFEWizard::Step
+    include ::DFEWizard::IssueVerificationCode
+
+    attribute :first_name
+    attribute :last_name
+    attribute :email
+
+    validates :email, presence: true
+    validates :first_name, presence: true
+    validates :last_name, presence: true
+  end
+
+  class StubIssueVerificationCodeWizard < DFEWizard::Base
+    self.steps = [IssueVerificationCodeStep].freeze
+  end
+
+  let(:attributes) { {} }
+  let(:wizard) { StubIssueVerificationCodeWizard.new(wizardstore, "issue_verification_code_step") }
+
+  describe "a step that issues a verification code" do
+    subject { IssueVerificationCodeStep.new wizard, wizardstore, attributes }
+
+    describe "#save" do
+      before do
+        subject.email = "email@address.com"
+        subject.first_name = "first"
+        subject.last_name = "last"
+      end
+
+      let(:request) do
+        GetIntoTeachingApiClient::ExistingCandidateRequest.new(
+          email: subject.email,
+          firstName: subject.first_name,
+          lastName: subject.last_name,
+          reference: wizard.reference,
+        )
+      end
+
+      it "purges previous data from the store" do
+        allow_any_instance_of(GetIntoTeachingApiClient::CandidatesApi).to receive(:create_candidate_access_token).with(request)
+        wizardstore["candidate_id"] = "abc123"
+        wizardstore["extra_data"] = "data"
+        subject.save
+        expect(wizardstore.to_hash).to eq(subject.attributes.merge({
+          "authenticate" => true,
+          "matchback_failures" => 0,
+          "last_matchback_failure_code" => nil,
+        }))
+      end
+
+      context "when invalid" do
+        it "does not call the API" do
+          subject.email = nil
+          subject.save
+          expect_any_instance_of(GetIntoTeachingApiClient::CandidatesApi).not_to receive(:create_candidate_access_token)
+          expect(wizardstore["authenticate"]).to be_falsy
+          expect(wizardstore["matchback_failures"]).to be_nil
+          expect(wizardstore["last_matchback_failure_code"]).to be_nil
+        end
+      end
+
+      context "when an existing candidate" do
+        it "sends verification code and sets authenticate to true" do
+          allow_any_instance_of(GetIntoTeachingApiClient::CandidatesApi).to receive(:create_candidate_access_token).with(request)
+          subject.save
+          expect(wizardstore["authenticate"]).to be_truthy
+          expect(wizardstore["matchback_failures"]).to eq(0)
+          expect(wizardstore["last_matchback_failure_code"]).to be_nil
+        end
+      end
+
+      it "will skip the authenticate step for new candidates" do
+        expect(Rails.logger).to receive(:info).with("#{IssueVerificationCodeStep} requesting access code")
+        expect(Rails.logger).not_to receive(:info).with("#{IssueVerificationCodeStep} potential duplicate (response code 404)")
+        allow_any_instance_of(GetIntoTeachingApiClient::CandidatesApi).to receive(:create_candidate_access_token).with(request)
+          .and_raise(GetIntoTeachingApiClient::ApiError.new(code: 404))
+        subject.save
+        expect(wizardstore["authenticate"]).to be_falsy
+        expect(wizardstore["matchback_failures"]).to eq(1)
+        expect(wizardstore["last_matchback_failure_code"]).to eq(404)
+      end
+
+      it "will skip the authenticate step if the CRM is unavailable" do
+        expect(Rails.logger).to receive(:info).with("#{IssueVerificationCodeStep} requesting access code")
+        expect(Rails.logger).to receive(:info).with("#{IssueVerificationCodeStep} potential duplicate (response code 500)")
+        allow_any_instance_of(GetIntoTeachingApiClient::CandidatesApi).to receive(:create_candidate_access_token).with(request)
+          .and_raise(GetIntoTeachingApiClient::ApiError.new(code: 500))
+        subject.save
+        expect(wizardstore["authenticate"]).to be_falsy
+        expect(wizardstore["matchback_failures"]).to eq(1)
+        expect(wizardstore["last_matchback_failure_code"]).to eq(500)
+      end
+
+      context "when the API rate limits the request" do
+        let(:too_many_requests_error) { GetIntoTeachingApiClient::ApiError.new(code: 429) }
+
+        it "will re-raise the ApiError (to be rescued by the ApplicationController)" do
+          allow_any_instance_of(GetIntoTeachingApiClient::CandidatesApi).to receive(:create_candidate_access_token).with(request)
+            .and_raise(too_many_requests_error)
+          expect { subject.save }.to raise_error(too_many_requests_error)
+          expect(wizardstore["authenticate"]).to be_nil
+          expect(wizardstore["matchback_failures"]).to eq(1)
+          expect(wizardstore["last_matchback_failure_code"]).to eq(429)
+        end
+      end
+
+      it "keeps track of how many times a matchback fails" do
+        allow_any_instance_of(GetIntoTeachingApiClient::CandidatesApi).to \
+          receive(:create_candidate_access_token).with(request)
+          .and_raise(GetIntoTeachingApiClient::ApiError.new(code: 404))
+
+        subject.save
+        expect(wizardstore["authenticate"]).to be_falsy
+        expect(wizardstore["matchback_failures"]).to eq(1)
+        expect(wizardstore["last_matchback_failure_code"]).to eq(404)
+
+        allow_any_instance_of(GetIntoTeachingApiClient::CandidatesApi).to \
+          receive(:create_candidate_access_token).with(request)
+          .and_raise(GetIntoTeachingApiClient::ApiError.new(code: 500))
+
+        subject.save
+        expect(wizardstore["matchback_failures"]).to eq(2)
+        expect(wizardstore["last_matchback_failure_code"]).to eq(500)
+
+        allow_any_instance_of(GetIntoTeachingApiClient::CandidatesApi).to \
+          receive(:create_candidate_access_token).with(request)
+
+        subject.save
+        expect(wizardstore["authenticate"]).to be_truthy
+        expect(wizardstore["matchback_failures"]).to eq(2)
+      end
+    end
+  end
+end

--- a/spec/dfe_wizard/step_spec.rb
+++ b/spec/dfe_wizard/step_spec.rb
@@ -11,12 +11,12 @@ describe DFEWizard::Step do
     validates :name, presence: true
   end
 
-  class StubWizard < DFEWizard::Base
+  class StubSingleStepWizard < DFEWizard::Base
     self.steps = [FirstStep].freeze
   end
 
   let(:attributes) { {} }
-  let(:wizard) { StubWizard.new(wizardstore, "first_step") }
+  let(:wizard) { StubSingleStepWizard.new(wizardstore, "first_step") }
 
   describe ".key" do
     it { expect(described_class.key).to eql "step" }

--- a/spec/dfe_wizard/steps/authenticate_spec.rb
+++ b/spec/dfe_wizard/steps/authenticate_spec.rb
@@ -67,6 +67,7 @@ describe DFEWizard::Steps::Authenticate, type: :model do
         email: wizardstore["email"],
         firstName: wizardstore["first_name"],
         lastName: wizardstore["last_name"],
+        reference: wizard.reference
       )
     end
 

--- a/spec/dfe_wizard/steps/authenticate_spec.rb
+++ b/spec/dfe_wizard/steps/authenticate_spec.rb
@@ -67,7 +67,7 @@ describe DFEWizard::Steps::Authenticate, type: :model do
         email: wizardstore["email"],
         firstName: wizardstore["first_name"],
         lastName: wizardstore["last_name"],
-        reference: wizard.reference
+        reference: wizard.reference,
       )
     end
 

--- a/spec/dfe_wizard_spec.rb
+++ b/spec/dfe_wizard_spec.rb
@@ -6,6 +6,6 @@ RSpec.describe DFEWizard do
   describe "VERSION" do
     subject { described_class::VERSION }
 
-    it { is_expected.to eql "0.1.1" }
+    it { is_expected.to eql "1.0.0" }
   end
 end


### PR DESCRIPTION
- Populate reference on ExistingCandidateRequest instances

Instead of defining this in the individual clients we can populate with the reference in the wizard gem, so that we
get a transaction-level reference for each wizard. 

Fix the `reference` method on `Wizard::Base` so it correctly handles namespaced wizards.

- Pull in IssueVerificationCode module

This module is still in both clients, but there's no reason it can't be pulled into the wizard gem and DRYed up. It also means we can populate the `reference` in the gem for the verification code request.