### PR TITLE
Update API client to v2

### DIFF
--- a/lib/dfe_wizard/controller.rb
+++ b/lib/dfe_wizard/controller.rb
@@ -38,7 +38,7 @@ module DFEWizard
     end
 
     def resend_verification
-      request = GetIntoTeachingApiClient::ExistingCandidateRequest.new(camelized_identity_data)
+      request = GetIntoTeachingApiClient::ExistingCandidateRequest.new(identity_data)
       GetIntoTeachingApiClient::CandidatesApi.new.create_candidate_access_token(request)
       redirect_to authenticate_path(verification_resent: true)
     rescue GetIntoTeachingApiClient::ApiError => e
@@ -52,7 +52,7 @@ module DFEWizard
     def process_skip_verification
       return unless request.query_parameters[:skip_verification]
 
-      request = GetIntoTeachingApiClient::ExistingCandidateRequest.new(camelized_identity_data)
+      request = GetIntoTeachingApiClient::ExistingCandidateRequest.new(identity_data)
       @wizard.process_unverified_request(request)
       wizard_store["authenticate"] = false
       redirect_to(step_after_authenticate_path)
@@ -134,9 +134,8 @@ module DFEWizard
       step_path :authenticate, params
     end
 
-    def camelized_identity_data
-      DFEWizard::Steps::Authenticate.new(nil, wizard_store)
-                                 .candidate_identity_data
+    def identity_data
+      DFEWizard::Steps::Authenticate.new(nil, wizard_store).candidate_identity_data
     end
   end
 end

--- a/lib/dfe_wizard/issue_verification_code.rb
+++ b/lib/dfe_wizard/issue_verification_code.rb
@@ -44,7 +44,6 @@ module DFEWizard
       attributes
         .slice("email", "first_name", "last_name")
         .merge({ "reference" => @wizard.reference })
-        .transform_keys { |k| k.camelize(:lower).to_sym }
     end
   end
 end

--- a/lib/dfe_wizard/steps/authenticate.rb
+++ b/lib/dfe_wizard/steps/authenticate.rb
@@ -32,9 +32,7 @@ module DFEWizard
       end
 
       def candidate_identity_data
-        @store.fetch(IDENTITY_ATTRS).compact.transform_keys do |k|
-          k.camelize(:lower).to_sym
-        end
+        @store.fetch(IDENTITY_ATTRS).compact
       end
 
     private

--- a/spec/dfe_wizard/base_spec.rb
+++ b/spec/dfe_wizard/base_spec.rb
@@ -111,9 +111,9 @@ describe DFEWizard::Base do
     let(:token) { "magic-link-token" }
     let(:stub_response) do
       {
-        candidateId: "abc123",
-        firstName: "John",
-        lastName: "Doe",
+        candidate_id: "abc123",
+        first_name: "John",
+        last_name: "Doe",
         email: "john@doe.com",
       }
     end
@@ -147,9 +147,9 @@ describe DFEWizard::Base do
     let(:token) { "access-token" }
     let(:stub_response) do
       {
-        candidateId: "abc123",
-        firstName: "John",
-        lastName: "Doe",
+        candidate_id: "abc123",
+        first_name: "John",
+        last_name: "Doe",
         email: "john@doe.com",
       }
     end
@@ -187,11 +187,11 @@ describe DFEWizard::Base do
     let(:request) { GetIntoTeachingApiClient::ExistingCandidateRequest.new }
     let(:stub_response) do
       GetIntoTeachingApiClient::TeachingEventAddAttendee.new(
-        candidateId: "abc123",
-        firstName: "John",
-        lastName: "Doe",
+        candidate_id: "abc123",
+        first_name: "John",
+        last_name: "Doe",
         email: "john@doe.com",
-        isVerified: false,
+        is_verified: false,
       )
     end
     let(:response_hash) { stub_response.to_hash.transform_keys { |k| k.to_s.underscore } }

--- a/spec/dfe_wizard/controller_spec.rb
+++ b/spec/dfe_wizard/controller_spec.rb
@@ -88,13 +88,11 @@ describe "EventStepsController", type: :request do
 
   describe "#show when skipping verification" do
     let(:step_path) { event_steps_path(readable_event_id, :authenticate, { skip_verification: true }) }
-    let(:camelized_identity_data) do
+    let(:identity_data) do
       {
-        candidateId: "abc123",
-        firstName: "John",
-        lastName: "Doe",
+        first_name: "John",
+        last_name: "Doe",
         email: "john@doe.com",
-        reference: "events_wizard-unverified",
       }
     end
 
@@ -102,12 +100,15 @@ describe "EventStepsController", type: :request do
       allow_any_instance_of(Events::Steps::PersonalDetails).to \
         receive(:is_walk_in?).and_return(true)
       allow_any_instance_of(DFEWizard::Steps::Authenticate).to \
-        receive(:candidate_identity_data) { camelized_identity_data }
+        receive(:candidate_identity_data) { identity_data }
     end
 
     context "when a candidate was previously matched" do
-      let(:request) { GetIntoTeachingApiClient::ExistingCandidateRequest.new(camelized_identity_data) }
-      let(:response) { GetIntoTeachingApiClient::TeachingEventAddAttendee.new(camelized_identity_data) }
+      let(:request) do
+        GetIntoTeachingApiClient::ExistingCandidateRequest.new \
+          identity_data.merge({ reference: "events_wizard-unverified" })
+      end
+      let(:response) { GetIntoTeachingApiClient::TeachingEventAddAttendee.new(identity_data) }
 
       before do
         allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \

--- a/spec/dfe_wizard/issue_verification_code_spec.rb
+++ b/spec/dfe_wizard/issue_verification_code_spec.rb
@@ -37,8 +37,8 @@ describe DFEWizard::IssueVerificationCode do
       let(:request) do
         GetIntoTeachingApiClient::ExistingCandidateRequest.new(
           email: subject.email,
-          firstName: subject.first_name,
-          lastName: subject.last_name,
+          first_name: subject.first_name,
+          last_name: subject.last_name,
           reference: wizard.reference,
         )
       end

--- a/spec/dfe_wizard/steps/authenticate_spec.rb
+++ b/spec/dfe_wizard/steps/authenticate_spec.rb
@@ -65,8 +65,8 @@ describe DFEWizard::Steps::Authenticate, type: :model do
     let(:request) do
       GetIntoTeachingApiClient::ExistingCandidateRequest.new(
         email: wizardstore["email"],
-        firstName: wizardstore["first_name"],
-        lastName: wizardstore["last_name"],
+        first_name: wizardstore["first_name"],
+        last_name: wizardstore["last_name"],
         reference: wizard.reference,
       )
     end
@@ -105,7 +105,7 @@ describe DFEWizard::Steps::Authenticate, type: :model do
 
     context "when TOTP is correct" do
       it "updates the store with the response" do
-        response = GetIntoTeachingApiClient::TeachingEventAddAttendee.new(candidateId: "abc123")
+        response = GetIntoTeachingApiClient::TeachingEventAddAttendee.new(candidate_id: "abc123")
         expect(wizard).to receive(:exchange_access_token).with(totp, request) { response }
         subject.save
         expect(wizardstore["candidate_id"]).to eq(response.candidate_id)


### PR DESCRIPTION
[Trello-2777](https://trello.com/c/oYLSzOTp/2777-monkey-patch-api-client-models-to-support-snakecase-attributes-in-initializer?filter=member:rossoliver15)

This change moves the attributes to use `snake_case` instead of `camelCase` on initialization.