### PR TITLE
Update index redirect to use 301 http status code

### DIFF
--- a/lib/dfe_wizard/controller.rb
+++ b/lib/dfe_wizard/controller.rb
@@ -13,7 +13,7 @@ module DFEWizard
 
     def index
       query_params = request.query_parameters
-      redirect_to step_path(wizard_class.first_key, query_params)
+      redirect_to(step_path(wizard_class.first_key, query_params), status: :moved_permanently)
     end
 
     def show

--- a/lib/dfe_wizard/version.rb
+++ b/lib/dfe_wizard/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DFEWizard
-  VERSION = "1.0.0"
+  VERSION = "1.0.1"
 end

--- a/spec/dfe_wizard/controller_spec.rb
+++ b/spec/dfe_wizard/controller_spec.rb
@@ -12,6 +12,7 @@ describe "EventStepsController", type: :request do
     before { get event_steps_path("123", query: "param") }
 
     it { is_expected.to redirect_to(event_step_path("123", { id: :personal_details, query: "param" })) }
+    it { is_expected.to have_http_status(:moved_permanently) }
   end
 
   describe "#show" do

--- a/spec/dfe_wizard_spec.rb
+++ b/spec/dfe_wizard_spec.rb
@@ -6,6 +6,6 @@ RSpec.describe DFEWizard do
   describe "VERSION" do
     subject { described_class::VERSION }
 
-    it { is_expected.to eql "1.0.0" }
+    it { is_expected.to eql "1.0.1" }
   end
 end


### PR DESCRIPTION
[Trello-3436](https://trello.com/c/rHWpgIQd/3436-change-internal-redirects-from-302-status-codes-to-301)

- Ensure initial sign up request returns 301

The way the wizard is setup it provides two paths to the initial step of the multi-stage form:

```
/sign_up
/sign_up/first_step
```

If we provide a link to the index path (`/sign_up`) then the user is redirected with a 302 HTTP status code (temporary redirect) by the Rails `redirect_to` helper. Instead, we should be using a 301 status code here for a permanent redirect.

- Bump patch version for release

> ⚠️ We will want to bump the gem version in all services once this is merged