### PR TITLE
Revert "Remove unused existing candidate fields"

### DIFF
--- a/lib/git_wizard/issue_verification_code.rb
+++ b/lib/git_wizard/issue_verification_code.rb
@@ -42,7 +42,7 @@ module GITWizard
 
     def request_attributes
       attributes
-        .slice("email")
+        .slice("email", "first_name", "last_name")
         .merge({ "reference" => @wizard.reference })
     end
   end

--- a/lib/git_wizard/steps/authenticate.rb
+++ b/lib/git_wizard/steps/authenticate.rb
@@ -7,7 +7,7 @@ module GITWizard
       BLANK_MESSAGE = "Enter the verification code sent to your email address".freeze
       WRONG_CODE_MESSAGE = "Please enter the latest verification code sent to your email address".freeze
 
-      IDENTITY_ATTRS = %i[email].freeze
+      IDENTITY_ATTRS = %i[email first_name last_name date_of_birth].freeze
 
       attribute :timed_one_time_password
 

--- a/lib/git_wizard/version.rb
+++ b/lib/git_wizard/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module GITWizard
-  VERSION = "2.2.0"
+  VERSION = "2.1.0"
 end

--- a/spec/git_wizard/controller_spec.rb
+++ b/spec/git_wizard/controller_spec.rb
@@ -89,7 +89,13 @@ describe "EventStepsController", type: :request do
 
   describe "#show when skipping verification" do
     let(:step_path) { event_steps_path(readable_event_id, :authenticate, { skip_verification: true }) }
-    let(:identity_data) { { email: "john@doe.com" } }
+    let(:identity_data) do
+      {
+        first_name: "John",
+        last_name: "Doe",
+        email: "john@doe.com",
+      }
+    end
 
     before do
       allow_any_instance_of(Events::Steps::PersonalDetails).to \

--- a/spec/git_wizard/issue_verification_code_spec.rb
+++ b/spec/git_wizard/issue_verification_code_spec.rb
@@ -37,6 +37,8 @@ describe GITWizard::IssueVerificationCode do
       let(:request) do
         GetIntoTeachingApiClient::ExistingCandidateRequest.new(
           email: subject.email,
+          first_name: subject.first_name,
+          last_name: subject.last_name,
           reference: wizard.reference,
         )
       end

--- a/spec/git_wizard/steps/authenticate_spec.rb
+++ b/spec/git_wizard/steps/authenticate_spec.rb
@@ -65,6 +65,8 @@ describe GITWizard::Steps::Authenticate, type: :model do
     let(:request) do
       GetIntoTeachingApiClient::ExistingCandidateRequest.new(
         email: wizardstore["email"],
+        first_name: wizardstore["first_name"],
+        last_name: wizardstore["last_name"],
         reference: wizard.reference,
       )
     end

--- a/spec/git_wizard_spec.rb
+++ b/spec/git_wizard_spec.rb
@@ -6,6 +6,6 @@ RSpec.describe GITWizard do
   describe "VERSION" do
     subject { described_class::VERSION }
 
-    it { is_expected.to eql "2.2.0" }
+    it { is_expected.to eql "2.1.0" }
   end
 end


### PR DESCRIPTION
Reverts DFE-Digital/get-into-teaching-wizard#14

Reverting this as it turns out `first_name` is still required in order for the email to go out successfully. 